### PR TITLE
Arrumado alguns problemas que faziam a simulação ficar presa no step 0

### DIFF
--- a/HW_HardDisk.cpp
+++ b/HW_HardDisk.cpp
@@ -77,7 +77,7 @@ void HW_HardDisk::setCommandRegister(unsigned int _commandRegister) {
             // schedule an event to notify it's ready
             simulator = Simulator::getInstance();
             entity = simulator->getEntity();
-            entity->getAttribute("MethodName")->setValue("HardDisk::interruptHandler()");
+            entity->getAttribute("MethodName")->setValue("HardDisk::interrupt_handler()");
             instantMovementFinished = simulator->getTnow() + headMovement * Traits<HW_HardDisk>::sectorMovementTime;
             simulator->insertEvent(instantMovementFinished, HW_Machine::Module_HardwareEvent(), entity);
             break;
@@ -106,7 +106,7 @@ void HW_HardDisk::setCommandRegister(unsigned int _commandRegister) {
             // schedule an event to notify it's ready
             simulator = Simulator::getInstance();
             entity = simulator->getEntity();
-            entity->getAttribute("MethodName")->setValue("HardDisk::interruptHandler()");
+            entity->getAttribute("MethodName")->setValue("HardDisk::interrupt_handler()");
             instantMovementFinished = simulator->getTnow() + headMovement * Traits<HW_HardDisk>::sectorMovementTime;
             simulator->insertEvent(instantMovementFinished, HW_Machine::Module_HardwareEvent(), entity);
             break;

--- a/Mediator_HardDisk.cpp
+++ b/Mediator_HardDisk.cpp
@@ -69,6 +69,6 @@ void HardDisk::setMaxBlocks(const HW_HardDisk::blockNumber maxBlocks) {
     
 }
 
-HW_HardDisk::blockNumber getMaxBlocks() {
+HW_HardDisk::blockNumber HardDisk::getMaxBlocks() {
     
 }

--- a/OperatingSystem.cpp
+++ b/OperatingSystem.cpp
@@ -64,16 +64,16 @@ void OperatingSystem::ExecuteTestCode() {
             simulator->insertEvent(timeNow + 10.0, module, entity); // future event when execution will advance 
             break;
         case 1:
-            entity->getAttribute("ExecutionStep")->setValue(std::to_string(executionStep++)); // advance execution step
+            entity->getAttribute("ExecutionStep")->setValue(std::to_string(++executionStep)); // advance execution step
             break;
         case 2:
-            entity->getAttribute("ExecutionStep")->setValue(std::to_string(executionStep++)); // advance execution step
+            entity->getAttribute("ExecutionStep")->setValue(std::to_string(++executionStep)); // advance execution step
             break;
         case 3:
-            entity->getAttribute("ExecutionStep")->setValue(std::to_string(executionStep++)); // advance execution step
+            entity->getAttribute("ExecutionStep")->setValue(std::to_string(++executionStep)); // advance execution step
             break;
         default:
-            //entity->getAttribute("ExecutionStep")->setValue(std::to_string(executionStep++)); // advance execution step
+            //entity->getAttribute("ExecutionStep")->setValue(std::to_string(++executionStep)); // advance execution step
             break;
     }
     

--- a/Traits.h
+++ b/Traits.h
@@ -141,7 +141,7 @@ template<> struct Traits<HW_HardDisk> {
     static constexpr unsigned int numSurfaces = 1;
     static constexpr unsigned int numTracksPerSurface = 1000;
     static constexpr unsigned int numSectorsPerTrack = 2;
-    static constexpr double sectorMovementTime = 10;  // time units to move head from one sector to another adjacent one
+    static constexpr double sectorMovementTime = 0.1;  // time units to move head from one sector to another adjacent one
 };
 
 


### PR DESCRIPTION
Olá professor, arrumei alguns problemas com a simulação e botei o 'sectorMovementTime' para 0.1 porque com tempo muito alto, requisições para tracks muito altas, 50+, vão fazer as próximas requisições nunca serem servidas, já que a simulação vai apenas até 500 unidades de tempo.